### PR TITLE
add option to disable hook

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,28 +54,34 @@ module.exports = function(sails) {
 
         //Defaults configurations
         defaults: {
-            // default key prefix for kue in
-            // redis server
-            prefix: 'q',
 
-            //default redis configuration
-            redis: {
-                //default redis server port
-                port: 6379,
-                //default redis server host
-                host: '127.0.0.1'
-            },
-            //number of milliseconds
-            //to wait for workers to 
-            //finish their current active job(s)
-            //before shutdown
-            shutdownDelay: 5000,
-            //number of millisecond to
-            //wait until promoting delayed jobs
-            promotionDelay: 5000,
-            //number of delated jobs
-            //to be promoted
-            promotionLimit: 200
+            __configKey__: {
+                // Set subscriber to be active by default
+                active: true,
+                // default key prefix for kue in
+                // redis server
+                prefix: 'q',
+
+                //default redis configuration
+                redis: {
+                    //default redis server port
+                    port: 6379,
+                    //default redis server host
+                    host: '127.0.0.1'
+                },
+                //number of milliseconds
+                //to wait for workers to 
+                //finish their current active job(s)
+                //before shutdown
+                shutdownDelay: 5000,
+                //number of millisecond to
+                //wait until promoting delayed jobs
+                promotionDelay: 5000,
+                //number of delated jobs
+                //to be promoted
+                promotionLimit: 200
+            }
+
         },
 
         //expose this hook kue worker pool
@@ -89,16 +95,19 @@ module.exports = function(sails) {
             //reference this hook
             var hook = this;
 
-            //extend defaults configuration
-            //with provided configuration from sails
-            //config
-            var config =
-                _.extend(hook.defaults, sails.config.subscriber);
+            //get extended config
+            var config = sails.config[this.configKey];
 
             // Lets wait on some of the sails core hooks to
             // finish loading before 
             // load `sails-hook-subscriber`
             var eventsToWaitFor = [];
+
+            // If the hook has been deactivated, just return
+            if (!config.active) {
+                sails.log.info('sails-hooks-subscriber deactivated.');
+                return done();
+            }
 
             if (sails.hooks.orm) {
                 eventsToWaitFor.push('hook:orm:loaded');

--- a/test/subscriber.spec.js
+++ b/test/subscriber.spec.js
@@ -14,12 +14,16 @@ describe('Hook#subscriber', function() {
     });
 
     it('should have defaults configuration', function(done) {
-        var subscriber = sails.hooks.subscriber;
+        expect(sails.config.subscriber).to.not.be.null;
+        expect(sails.config.subscriber.prefix).to.equal('q');
+        expect(sails.config.subscriber.redis.port).to.equal(6379);
+        expect(sails.config.subscriber.redis.host).to.equal('127.0.0.1');
 
-        expect(subscriber.defaults).to.not.be.null;
-        expect(subscriber.defaults.prefix).to.equal('q');
-        expect(subscriber.defaults.redis.port).to.equal(6379);
-        expect(subscriber.defaults.redis.host).to.equal('127.0.0.1');
+        done();
+    });
+
+    it('should be active per default', function(done) {
+        expect(sails.config.subscriber.active).to.be.true;
 
         done();
     });


### PR DESCRIPTION
It would be awesome being able to disable this hook.
This allows us to load this hook in a separate process. e.g.:

```
require('sails').lift({
  hooks: {
    blueprints: false,
    controllers: false,
    cors: false,
    csrf: false,
    grunt: false,
    http: false,
    i18n: false,
    // logger: false,
    // orm: leave default hook
    policies: false,
    pubsub: false,
    request: false,
    responses: false,
    // services: leave default hook,
    session: false,
    sockets: false,
    views: false
  },
  subscriber:  {
    active: true
  }
}, function(error, sails) {
  if (error)
    return sails.log.error(error);

  sails.log('Sails worker started successful.');

});
```

http://stackoverflow.com/questions/30580472/disable-user-hook-in-sails
