### PR TITLE
Support setting a job type prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,9 @@ module.exports.subscriber = {
     promotionLimit: 200,
     
     //prefix to add to job types
-    jobTypePrefix: ''
+    jobTypePrefix: '',
+    //prefix to add to uppercase letters in the job type (except first uppercase letter)
+    jobTypePrefixUppercase: ''
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,10 @@ module.exports.subscriber = {
     promotionDelay: 5000,
     //number of delated jobs
     //to be promoted
-    promotionLimit: 200
+    promotionLimit: 200,
+    
+    //prefix to add to job types
+    jobTypePrefix: ''
 }
 ```
 
@@ -136,6 +139,8 @@ $ npm install
 ```sh
 $ npm test
 ```
+
+**Note**: If you don't have `grunt-cli` installed, the tests may not run correctly. Install `grunt-cli` globally with `npm install -g grunt-cli`
 
 ## Contribute
 

--- a/api/workers/MultipleWordsWorker.js
+++ b/api/workers/MultipleWordsWorker.js
@@ -1,0 +1,60 @@
+/**
+ * @description a worker to perform `email` job type
+ * @type {Object}
+ */
+var async = require('async');
+module.exports = {
+    //worker concurrency
+    concurrency: 2,
+
+    //sending emails
+    //note!: we have access of
+    //of all of sails
+    perform: function(job, context, done) {
+        var email = job.data.to;
+
+        //send email
+
+        //update sails model
+        async
+        .waterfall(
+            [
+                function(next) {
+                    //send email codes here
+                    next(null, {
+                        sentAt: new Date(),
+                        status: 'Ok'
+                    });
+                },
+                function(deliveryStatus, next) {
+                    User
+                        .findOneByEmail(email)
+                        .exec(function(error, user) {
+                            if (error) {
+                                next(error);
+                            } else {
+                                user.emailSentAt = deliveryStatus.sentAt
+                                next(null, user, deliveryStatus);
+                            }
+                        });
+                },
+                function(user, deliveryStatus, next) {
+                    user.save(function(error, user) {
+                        if (error) {
+                            next(error);
+                        } else {
+                            next(null, user, deliveryStatus);
+                        }
+                    });
+                }
+            ],
+            function(error, user, deliveryStatus) {
+                if (error) {
+                    done(error);
+                } else {
+                    done(null, deliveryStatus);
+                }
+            });
+    }
+
+};

--- a/config/subscriber.js
+++ b/config/subscriber.js
@@ -20,5 +20,8 @@ module.exports.subscriber = {
     promotionDelay: 6000,
     //number of delated jobs
     //to be promoted
-    promotionLimit: 300
+    promotionLimit: 300,
+
+    //prefix to add to job types
+    jobTypePrefix: ''
 }

--- a/config/subscriber.js
+++ b/config/subscriber.js
@@ -23,5 +23,8 @@ module.exports.subscriber = {
     promotionLimit: 300,
 
     //prefix to add to job types
-    jobTypePrefix: ''
+    jobTypePrefix: '',
+
+    //prefix to add to uppercase letters in the job type (except first uppercase letter)
+    jobTypePrefixUppercase: ''
 }

--- a/index.js
+++ b/index.js
@@ -12,6 +12,29 @@ module.exports = function(sails) {
     var kue = require('kue');
     var _ = require('lodash');
 
+    /**
+     * Determines the job type of a worker.
+     *
+     * @param {string} worker Filename (without .js suffix) of worker
+     * @param {object} config Configuration object for this hook
+     * @returns {string}
+     */
+    function getJobType(worker, config) {
+        var jobType = config.jobTypePrefix + worker.replace(/Worker$/, '');
+
+        // Prefix all uppercase letters (except the first one)
+        if (config.jobTypePrefixUppercase) {
+            // Convert first letter to lowercase, so that doesn't get prefixed.
+            jobType = jobType
+                    .replace(/\W+/g, config.jobTypePrefixUppercase)
+                    .replace(/([a-z\d])([A-Z])/g, '$1' + config.jobTypePrefixUppercase + '$2');
+        }
+        // Convert job type entirely to lowercase
+        jobType = jobType.toLowerCase();
+
+        return jobType;
+    }
+
     //workers loader
     function initializeWorkers(config) {
         //find all workers
@@ -26,8 +49,8 @@ module.exports = function(sails) {
         //attach all workers to queue
         //ready to process their jobs
         _.keys(workers).forEach(function(worker) {
-            //deduce job type form worker name (add prefix)
-            var jobType = config.jobTypePrefix + worker.replace(/Worker$/, '').toLowerCase();
+            // deduce job type form worker name (add prefix)
+            var jobType = getJobType(worker, config);
 
             //grab worker definition from
             //loaded workers
@@ -84,7 +107,9 @@ module.exports = function(sails) {
                 promotionLimit: 200,
 
                 //prefix to add to job types
-                jobTypePrefix: ''
+                jobTypePrefix: '',
+                //prefix to add to uppercase letters in the job type (except first uppercase letter)
+                jobTypePrefixUppercase: ''
             }
 
         },

--- a/test/subscriber.spec.js
+++ b/test/subscriber.spec.js
@@ -19,6 +19,7 @@ describe('Hook#subscriber', function() {
         expect(sails.config.subscriber.redis.port).to.equal(6379);
         expect(sails.config.subscriber.redis.host).to.equal('127.0.0.1');
         expect(sails.config.subscriber.jobTypePrefix).to.equal('');
+        expect(sails.config.subscriber.jobTypePrefixUppercase).to.equal('');
 
         done();
     });


### PR DESCRIPTION
Allow setting a `config.jobTypePrefix`, which will be prefixed all job types. E.g. with a `jobTypePrefix: 'myjob.'`, a worker with the filename `EmailWorker.js` will have the job type `myjob.email`.

Also support setting a prefix to add to uppercase letters in the worker name.
As an example, if the prefix is '.' (a dot), and the worker filename is 'MultipleWordsWorker.js', the job type will be 'multiple.words'

Default setting is empty string for both values (unchanged behaviour)
