### PR TITLE
Update Kue version to newest (0.10.5). Bump version to 1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "sails-hook-subscriber",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "Kue based job subscriber(consumer and workers pool) for sails",
     "main": "index.js",
     "scripts": {
@@ -39,7 +39,7 @@
     },
     "dependencies": {
         "include-all": "^0.1.6",
-        "kue": "^0.9.4",
+        "kue": "^0.10.5",
         "lodash": "^3.10.1"
     },
     "devDependencies": {


### PR DESCRIPTION
Kue 0.9.4 is over 6 months old. Let's use the newest version! :-)
