### PR TITLE
Allow to override Redis defaults settings from global sails.config.redis

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,9 +74,10 @@ module.exports = function(sails) {
       //get extended default config
       var config = sails.config[this.configKey] || {};
       // extend any custom redis configs based on specific global env config
-      if (sails.config.redis) 
-        config = Object.assign(config, {'redis':Object.assign(config.redis, sails.config.redis)})
-    
+      if (sails.config.redis) {
+        config = Object.assign(config, {'redis':Object.assign(config.redis, sails.config.redis)});
+      }
+  
       return config;
     }
 

--- a/index.js
+++ b/index.js
@@ -68,11 +68,9 @@ module.exports = function(sails) {
         });
     }
     /**
-     * Retrieve the default hooks configs with any other global redis config
+     * Extend the default hooks configs with any other global redis config
      */
-    function getDefaultConfig() {
-      //get extended default config
-      var config = sails.config[this.configKey] || {};
+    function extendDefaultConfig(config) {
       // extend any custom redis configs based on specific global env config
       if (sails.config.redis) {
         config = Object.assign(config, {'redis':Object.assign(config.redis, sails.config.redis)});
@@ -138,7 +136,7 @@ module.exports = function(sails) {
             var hook = this;
 
             //get extended config
-            var config = getDefaultConfig.call(this);
+            var config = extendDefaultConfig(sails.config[this.configKey]);
 
             // Lets wait on some of the sails core hooks to
             // finish loading before 
@@ -201,7 +199,7 @@ module.exports = function(sails) {
             sails.log.info('Reloading sails-hook-subscriber.');
             done = done || function(){};
             //get extended config
-            var config = getDefaultConfig.call(this);
+            var config = extendDefaultConfig(sails.config[this.configKey]);
 
             subscriber.workers = [];
 

--- a/index.js
+++ b/index.js
@@ -67,6 +67,18 @@ module.exports = function(sails) {
                 );
         });
     }
+    /**
+     * Retrieve the default hooks configs with any other global redis config
+     */
+    function getDefaultConfig() {
+      //get extended default config
+      var config = sails.config[this.configKey] || {};
+      // extend any custom redis configs based on specific global env config
+      if (sails.config.redis) 
+        config = Object.assign(config, {'redis':Object.assign(config.redis, sails.config.redis)})
+    
+      return config;
+    }
 
     //reference kue based queue
     var subscriber;
@@ -125,7 +137,7 @@ module.exports = function(sails) {
             var hook = this;
 
             //get extended config
-            var config = sails.config[this.configKey];
+            var config = getDefaultConfig.call(this);
 
             // Lets wait on some of the sails core hooks to
             // finish loading before 
@@ -188,7 +200,7 @@ module.exports = function(sails) {
             sails.log.info('Reloading sails-hook-subscriber.');
             done = done || function(){};
             //get extended config
-            var config = sails.config[this.configKey];
+            var config = getDefaultConfig.call(this);
 
             subscriber.workers = [];
 

--- a/test/bootstrap.spec.js
+++ b/test/bootstrap.spec.js
@@ -15,6 +15,9 @@ before(function(done) {
         .lift({ // configuration for testing purposes
             port: 7070,
             environment: 'test',
+            redis: {
+              host: '127.0.0.1'
+            },
             log: {
                 noShip: true
             },

--- a/test/subscriber.spec.js
+++ b/test/subscriber.spec.js
@@ -24,6 +24,11 @@ describe('Hook#subscriber', function() {
         done();
     });
 
+    it('should be able to use redis config from global sails.config', function(done) {
+      expect(sails.config.subscriber.redis.host).to.equal(sails.config.redis.host);
+      done();
+    });
+
     it('should be active per default', function(done) {
         expect(sails.config.subscriber.active).to.be.true;
 


### PR DESCRIPTION
# Problem 
Certain users may need the ability  to set different Redis connection settings on different server environments, Ex. Staging or Production.

# Proposed Solution
Allow the hook to receive and override Redis config from a global `sails.config.redis`.  This provides flexibility to specify custom configurations on different server environments. 

Any feedback is welcomed.

Thanks!